### PR TITLE
Add options type to ExCommit and ExDispatch

### DIFF
--- a/types/shims-vuex-type.d.ts
+++ b/types/shims-vuex-type.d.ts
@@ -16,11 +16,13 @@ declare module 'vuex' {
   type Mutations<S, M> = { [K in keyof M]: (state: S, payload: M[K]) => void }
   // ______________________________________________________
   //
-  type ExCommit<M> = <T extends keyof M>(type: T, payload?: M[T], options?: CommitOptions) => void
-  type ExDispatch<A> = <T extends keyof A>(type: T, payload?: A[T], options?: DispatchOptions) => any
+  type ExCommit<M> = <T extends keyof M>(type: T, payload?: M[T]) => void
+  type ExRootCommit = <T extends keyof RootMutations>(type: T, payload?: RootMutations[T], options?: CommitOptions) => void
+  type ExDispatch<A> = <T extends keyof A>(type: T, payload?: A[T]) => any
+  type ExRootDispatch = <T extends keyof RootActions>(type: T, payload?: RootActions[T], options?: DispatchOptions) => any
   type ExActionContext<S, A, G, M> = {
-    commit: ExCommit<M>
-    dispatch: ExDispatch<A>
+    commit: ExCommit<M> & ExRootCommit
+    dispatch: ExDispatch<A> & ExRootDispatch
     state: S
     getters: G
     rootState: RootState

--- a/types/shims-vuex-type.d.ts
+++ b/types/shims-vuex-type.d.ts
@@ -16,8 +16,8 @@ declare module 'vuex' {
   type Mutations<S, M> = { [K in keyof M]: (state: S, payload: M[K]) => void }
   // ______________________________________________________
   //
-  type ExCommit<M> = <T extends keyof M>(type: T, payload?: M[T]) => void
-  type ExDispatch<A> = <T extends keyof A>(type: T, payload?: A[T]) => any
+  type ExCommit<M> = <T extends keyof M>(type: T, payload?: M[T], options?: CommitOptions) => void
+  type ExDispatch<A> = <T extends keyof A>(type: T, payload?: A[T], options?: DispatchOptions) => any
   type ExActionContext<S, A, G, M> = {
     commit: ExCommit<M>
     dispatch: ExDispatch<A>


### PR DESCRIPTION
vuexの型定義（`shims-vuex-type.d.ts`）にグローバル名前空間のactions/mutationsを実行できるような型を追加いたしました。

## 概要

dispatch/commitをするときに `{ root: true }` を使いたいときがあります。
そのためvuex本家の型定義を参考に追加いたしました 🙏 
https://github.com/vuejs/vuex/blob/d3979fddd589df7d8d74f9bf0772752675f50abb/types/index.d.ts#L41-L49

書籍（実践TypeScript）と内容が変わってしまうため、不要でしたらそのままクローズしていただいて問題ありません 👍 


## サンプルコード
```ts
export const actions: Actions<S, A, G, M> = {
  asyncSetCount(ctx, payload) {
    // 同一store
    ctx.commit('setCount', { amount: payload.amount })
    ctx.dispatch('asyncIncrement')
    // global
    ctx.commit('todos/doneTodo', { id: 'xxxx' }, { root: true })
    ctx.dispatch('todos/asyncDoneTodo', { id: 'xxx' }, { root: true })
}
```
